### PR TITLE
Fix swapped solar/charger descriptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,18 +147,18 @@ module.exports = function (app) {
                                 {
                                     "path": "electrical.batteries.solarYieldToday",
                                     "value": {
-                                        "description": "Total energy from charger today",
+                                        "description": "Total energy from solar charger today",
                                         "units": "Ah",
-                                        "displayName": "Energy from charger today",
+                                        "displayName": "Energy from solar charger today",
                                         "timeout": 30
                                     },
                                 },
                                 {
                                     "path": "electrical.batteries.chargerYieldToday",
                                     "value": {
-                                        "description": "Total energy from solar charger today",
+                                        "description": "Total energy from charger today",
                                         "units": "Ah",
-                                        "displayName": "Energy from solar charger today",
+                                        "displayName": "Energy from charger today",
                                         "timeout": 30
                                     },
                                 }


### PR DESCRIPTION
## Summary
- correct the descriptions for solarYieldToday and chargerYieldToday

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68468e30176883299940808d8a829a79